### PR TITLE
Add release process to migrate on deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: python manage.py migrate
 web: gunicorn CZ3003CMS.wsgi --log-file -


### PR DESCRIPTION
<!-- Why was this change necessary? -->
**Why**
Previously, automatic deployment on a new push to master branch did not include a following migration of the database. Solves Issue #25.

<!-- How does it address the problem? -->
**How**
Edited the `Procfile` to include a `release` [process](https://devcenter.heroku.com/articles/release-phase#when-does-the-release-command-run), this runs `python manage.py migrate` after the app is built but before it's deployed.
Note that **this has not been really tested** as a new push to master is required to see if it works!

<!-- Are there any side effects? -->
**Side Effects**
Migrations must now succeed before deployment is successful.
